### PR TITLE
Fixed the images css and js links for handlebars 😭🎉

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const session = require('express-session');
-const exphbs  = require('express-handlebars');
+const exphbs = require('express-handlebars');
 const path = require('path');
 const routes = require('./controllers');
 const helpers = require('./utils/helpers');
@@ -47,7 +47,5 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(routes);
 
 sequelize.sync({ force: false }).then(() => {
-    app.listen(PORT, () => console.log('Now listening'));
-  });
-
-
+  app.listen(PORT, () => console.log('Now listening'));
+});

--- a/views/SignInPage.handlebars
+++ b/views/SignInPage.handlebars
@@ -8,7 +8,7 @@
     <title>Sign-In Page</title>
     <!-- Compiled and minified CSS DOCUMENTATION FROM MATERIALIZE -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
-    <link rel="stylesheet" type="text/css" href="public\style.css">
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
 </head>
 
 <body>
@@ -16,7 +16,7 @@
     <header class="header"></header>
     <div Class="signInPage">
         <h1>WELCOME</h1>
-        <h2><img class="homeLogo" src="./HOME.png" width="625px" height="179px"></h2>
+        <h2><img class="homeLogo-SignIn" src="/images/HOME.png" width="625px" height="179px"></h2>
         <!-- SIGN IN FORM TAKEN FROM MATERIALIZE -->
         <div class="row">
             <form class="col s12 form">
@@ -45,7 +45,7 @@
     </div>
     <!-- Compiled and minified JavaScript FROM MATERIALIZE -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script src="../public/js/signIn.js"></script>
+    <script src="/js/signIn.js"></script>
 </body>
 
 </html>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -9,10 +9,11 @@
     <!-- Compiled and minified CSS documentation for Materialize -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="public\css\mainpage.css">
+    <link rel="stylesheet" type="text/css" href="/css/mainpage.css">
 </head>
 
 <body>
+    <header>
       <nav>
         <!-- Conditionally render login or logout links -->
         {{#if logged_in}}

--- a/views/mainpage.handlebars
+++ b/views/mainpage.handlebars
@@ -9,14 +9,14 @@
     <!-- Compiled and minified CSS documentation for Materialize -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="public\css\mainpage.css">
+    <link rel="stylesheet" type="text/css" href="\css\mainpage.css">
 </head>
 
 <body>
     <!-- This is the Header of the page -->
     <header class="header">
         <div class="homeLogo">
-            <img src="public\images\HOME.png" width="525px" height="135px">
+            <img src="\images\HOME.png" width="525px" height="135px">
         </div>
     </header>
     <!-- POP OUT NAV/PROFILE CARD FROM MATERIALIZE -->
@@ -24,9 +24,9 @@
         <li>
             <div class="user-view">
                 <div class="background">
-                    <img src="public\images\profile-banner.png">
+                    <img src="\images\profile-banner.png">
                 </div>
-                <a href="#user"><img class="circle" src="public\images\ProfileLogo.png"></a>
+                <a href="#user"><img class="circle" src="\images\ProfileLogo.png"></a>
                 <a href="#name"><span class="white-text name">John Doe</span></a>
                 <a href="#email"><span class="white-text email">User Email Goes Here</span></a>
             </div>
@@ -73,10 +73,10 @@
     </ul>
 
 
-    <script src="public\js\mainpage.js"></script>
+    <script src="\js\mainpage.js"></script>
     <!-- Compiled and minified JavaScript -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script src="../public/js/mainpage.js"></script>
+    <script src="/js/mainpage.js"></script>
 </body>
 
 </html>

--- a/views/signUpPage.handlebars
+++ b/views/signUpPage.handlebars
@@ -8,14 +8,14 @@
     <title>Document</title>
     <!-- Compiled and minified CSS documentation for Materialize -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
-    <link rel="stylesheet" type="text/css" href="/public/css/signup.css">
+    <link rel="stylesheet" type="text/css" href="/css/signup.css">
 </head>
 
 <body>
     <!-- This is the Header of the page -->
     <header class="header">
         <div class="homeLogo">
-            <img src="/public/images/HOME.png" width="525px" height="135px">
+            <img src="/images/HOME.png" width="525px" height="135px">
         </div>
     </header>
     <div Class="account">
@@ -54,7 +54,7 @@
 
     <!-- Compiled and minified JavaScript -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script src="../public/js/signUp.js"></script>
+    <script src="/js/signUp.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
##  Updates 
- The ```images css and js links``` should be working on at least the main page and sign in page.  
‼**STILL NEED TO CHECK SIGN UP PAGE LINKS**‼

- I adjusted the paths to them because the GET request was looking for a public folder ```within``` the public folder so I took out public within each link. So instead of ```public\css\mainpage.css``` we have ```css\mainpage.css```.

- The side profile should pull out when selecting the hamburger icon on the main page 🎉
- Changed the home logo class name to ```homeLogo-SignIn``` under ```SignInPage.handlebars``` to center the logo.